### PR TITLE
Synchronize search_flag in template

### DIFF
--- a/kboard/board/models.py
+++ b/kboard/board/models.py
@@ -48,8 +48,11 @@ class PostManager(models.Manager):
 
 
 class Post(TimeStampedModel):
-    def get_absolute_url(self):
-        return reverse('board:view_post', args=[self.id])
+    SEARCH_FLAG = [
+        ('TITLE', '제목'),
+        ('CONTENT', '내용'),
+        ('BOTH', '제목+내용')
+    ]
 
     objects = PostManager()
 
@@ -58,6 +61,9 @@ class Post(TimeStampedModel):
     board = models.ForeignKey(Board, null=True)
     is_deleted = models.BooleanField(default=False)
     page_view_count = models.IntegerField(default=0)
+
+    def get_absolute_url(self):
+        return reverse('board:view_post', args=[self.id])
 
 
 class SummerNote(summer_model.Attachment):

--- a/kboard/board/templates/post_list.html
+++ b/kboard/board/templates/post_list.html
@@ -33,9 +33,10 @@
         <div class="col-sm-6">
         <form method="GET" class="form-inline">
             <select name="search_flag" class="form-control search-flag">
-                <option value="TITLE">제목</option>
-                <option value="CONTENT">내용</option>
-                <option value="BOTH">제목+내용</option>
+                {% for key, value in search_info.flags %}
+                    <option value="{{ key }}"
+                            {% if search_info.selected_flag == key %} selected {% endif %}>{{ value }}</option>
+                {% endfor %}
             </select>
             <div class="input-group">
                 <input type="text" class="form-control" name="query"

--- a/kboard/board/tests/test_models.py
+++ b/kboard/board/tests/test_models.py
@@ -68,6 +68,18 @@ class PostModelTest(BoardAppTest):
 
         self.assertEqual(Post.objects.search('NOT_A_FLAG', 'any query').count(), repeat)
 
+    def test_search_does_not_consider_upper_or_lower_letter(self):
+        repeat = 3
+        for i in range(repeat):
+            Post.objects.create(
+                board=self.default_board,
+                title='hI, ' + str(i),
+                content='ConTeNt ' + str(i)
+            )
+
+        self.assertEqual(Post.objects.search('TITLE', 'hi').count(), repeat)
+        self.assertEqual(Post.objects.search('CONTENT', 'content').count(), repeat)
+
 
 class CommentModelTest(BoardAppTest):
     @classmethod

--- a/kboard/board/views.py
+++ b/kboard/board/views.py
@@ -22,14 +22,16 @@ def new_post(request, board_slug):
 
 def post_list(request, board_slug):
     board = Board.objects.get(slug=board_slug)
+
     # search
     search_info = {
         'query': request.GET.get('query', ''),
-        'flag': request.GET.get('search_flag', '')
+        'selected_flag': request.GET.get('search_flag', 'TITLE'),
+        'flags': Post.SEARCH_FLAG
     }
 
     if search_info['query']:
-        posts = Post.objects.get_from_board(board).remain().search(search_info['flag'], search_info['query'])\
+        posts = Post.objects.get_from_board(board).remain().search(search_info['selected_flag'], search_info['query'])\
             .order_by('-id')
     else:
         posts = Post.objects.get_from_board(board).remain().order_by('-id')

--- a/kboard/functional_test/test_post_search.py
+++ b/kboard/functional_test/test_post_search.py
@@ -81,9 +81,13 @@ class SearchPostTest(FunctionalTest):
         input_search = self.browser.find_element_by_css_selector("input[name='query']")
         self.assertEqual(input_search.get_attribute('value'), 'fun')
 
+        # 분류가 '내용'으로 선택되어있다.
+        search_flag = Select(self.browser.find_element_by_css_selector("select[name='search_flag']"))
+        selected_option = search_flag.first_selected_option
+        self.assertEqual(selected_option.text, '내용')
+
         # 적고 난 뒤에 'overwatch'를 찾으려고 한다.
         # 분류를 '제목+내용'으로 선택한다.
-        search_flag = Select(self.browser.find_element_by_css_selector("select[name='search_flag']"))
         search_flag.select_by_visible_text('제목+내용')
 
         # 검색란에 'overwatch'라고 입력한다.
@@ -98,3 +102,8 @@ class SearchPostTest(FunctionalTest):
         searched_posts = self.browser.find_elements_by_css_selector('#id_post_list_table tbody tr')
         self.assertEqual(len(searched_posts), 1)
         self.check_for_row_in_list_table('id_post_list_table', 'league of legend')
+
+        # 분류가 '제목+내용'으로 선택되어있다.
+        search_flag = Select(self.browser.find_element_by_css_selector("select[name='search_flag']"))
+        selected_option = search_flag.first_selected_option
+        self.assertEqual(selected_option.text, '제목+내용')


### PR DESCRIPTION
Now search flag in 'post_list' page will be remained when you click search button.

- Add search_flag constant into const.py
- Modify 'post_list' view&template, PostManager to refer and use const.py's search_flag data
- Add functional_test due to synchronizing search flag