### PR TITLE
Change pipeline path to compile all depth of directory

### DIFF
--- a/kboard/kboard/settings.py
+++ b/kboard/kboard/settings.py
@@ -134,7 +134,7 @@ PIPELINE = {
     'JAVASCRIPT': {
         'main': {
             'source_filenames': [
-              'js/*.js'
+              'js/**/*.js'
             ],
             'output_filename': 'js/vendor.js'
         },
@@ -142,7 +142,7 @@ PIPELINE = {
     'STYLESHEETS': {
         'main': {
             'source_filenames': [
-              'style/*.scss'
+              'style/**/*.scss'
             ],
             'output_filename': 'style/main.css'
         },


### PR DESCRIPTION
Now pipeline compiles not only `js/[name].js`, but also `js/[directory/...]/[name].js`.
Scss is the same with Js