### PR TITLE
Don't save edited history while post is invalid

### DIFF
--- a/kboard/board/tests/test_views.py
+++ b/kboard/board/tests/test_views.py
@@ -324,6 +324,14 @@ class EditPostTest(BoardAppTest):
         self.assertContains(response, EMPTY_TITLE_ERROR)
         self.assertContains(response, EMPTY_CONTENT_ERROR)
 
+    def test_does_not_save_history_while_invalid(self):
+        self.assertEqual(EditedPostHistory.objects.count(), 0)
+        response = self.client.post(reverse('board:edit_post', args=[self.default_post.id]), {
+            'title': '',
+            'content': 'content',
+        })
+        self.assertEqual(EditedPostHistory.objects.count(), 0)
+
 
 class NewCommentTest(BoardAppTest):
     @classmethod

--- a/kboard/board/views.py
+++ b/kboard/board/views.py
@@ -118,13 +118,19 @@ def post_history_list(request, post_id):
 
 def edit_post(request, post_id):
     post = Post.objects.get(id=post_id)
+    origin_post = Post.objects.get(id=post_id)
 
     if request.method == 'POST':
         post_form = PostForm(request.POST, instance=post)
         if post.title != request.POST['title'] or post.content != request.POST['content']:
-            edited_post_history = EditedPostHistory.objects.create(post=post, title=post.title, content=post.content)
-            edited_post_history.save()
             if post_form.is_valid():
+                edited_post_history = EditedPostHistory.objects.create(
+                    post=origin_post,
+                    title=origin_post.title,
+                    content=origin_post.content,
+                )
+                edited_post_history.save()
+
                 post_form.save()
                 return redirect(post)
         else:


### PR DESCRIPTION
- Add test that doesn't save history while invalid
- Move creating history logic into is_valid in edit post view