### PR TITLE
Add password reset/change basic template

### DIFF
--- a/kboard/accounts/templates/registration/password_change_done.html
+++ b/kboard/accounts/templates/registration/password_change_done.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+<p>{% trans "Password changed" %}</p>
+{% endblock %}

--- a/kboard/accounts/templates/registration/password_change_form.html
+++ b/kboard/accounts/templates/registration/password_change_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+<form method="post" action=".">
+  {% csrf_token %} 
+  {{ form.as_p }}
+
+  <input type="submit" value="{% trans 'Submit' %}" />
+</form>
+{% endblock %}

--- a/kboard/accounts/templates/registration/password_reset_complete.html
+++ b/kboard/accounts/templates/registration/password_reset_complete.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+
+<p>{% trans "Password reset successfully" %}</p>
+
+<p><a href="{% url 'auth_login' %}">{% trans "Log in" %}</a></p>
+
+{% endblock %}

--- a/kboard/accounts/templates/registration/password_reset_confirm.html
+++ b/kboard/accounts/templates/registration/password_reset_confirm.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+
+{% if validlink %}
+
+<form method="post" action=".">
+  {% csrf_token %} 
+  {{ form.as_p }}
+
+  <input type="submit" value="{% trans 'Submit' %}" />
+</form>
+
+{% else %}
+
+<p>{% trans "Password reset failed" %}</p>
+
+{% endif %}
+
+{% endblock %}

--- a/kboard/accounts/templates/registration/password_reset_done.html
+++ b/kboard/accounts/templates/registration/password_reset_done.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+<p>{% trans "Email with password reset instructions has been sent." %}</p>
+{% endblock %}

--- a/kboard/accounts/templates/registration/password_reset_form.html
+++ b/kboard/accounts/templates/registration/password_reset_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body %}
+<form method="post" action=".">
+    {% csrf_token %}
+    {{ form.as_p }}
+
+    <input type="submit" value="{% trans 'Submit' %}" />
+</form>
+{% endblock %}

--- a/kboard/accounts/urls.py
+++ b/kboard/accounts/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import url, include
-from accounts.views import RegistrationView
-from accounts.forms import RegistrationForm
+from django.conf.urls import url
 
 from . import views
+
 
 app_name = 'accounts'
 urlpatterns = [

--- a/kboard/functional_test/test_post_validation.py
+++ b/kboard/functional_test/test_post_validation.py
@@ -1,4 +1,5 @@
 from .base import FunctionalTest
+import time
 
 
 class PostValidationTest(FunctionalTest):
@@ -51,5 +52,6 @@ class PostValidationTest(FunctionalTest):
         contentbox = self.get_contentbox()
         contentbox.send_keys('Content of This Post')
         self.browser.switch_to.default_content()
+        time.sleep(1)
         self.click_submit_button()
         self.check_for_row_in_list_table('id_post_list_table', 'Title of This Post')

--- a/kboard/kboard/settings.py
+++ b/kboard/kboard/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'accounts',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -43,7 +44,6 @@ INSTALLED_APPS = [
     'django_summernote',
     'djangobower',
     'pipeline',
-    'accounts',
 ]
 
 STATICFILES_FINDERS = [


### PR DESCRIPTION
* password reset/change 템플릿이 먹지 않았던 이유는 `settings.py`의 `INSTALLED_APPS`의 순서 때문이었다. 
* `INSTALLED_APPS`에서 뒤에 있는 것이 앞에있는 것을 덮어 씌우는줄 알았는데 url 찾는것과 비슷하게 앞쪽에 매칭되는 것이 있으면 그걸로 실행이 되는 것 같다.
* `'django.contrib.admin'`의 앞쪽에 `'accounts'`를 선언해서 해결(....)
* http://stackoverflow.com/questions/34817448/rendering-custom-templates-for-django-registration-redux